### PR TITLE
Improve user mentions

### DIFF
--- a/src/actions/message.ts
+++ b/src/actions/message.ts
@@ -15,12 +15,7 @@ import { handleOnMessage } from './notification';
 
 import { stringToHexColor } from '../utils/colorUtils';
 import { makeId } from '../utils/stringUtils';
-import {
-  getRegExpWithAt,
-  getRegExpWithoutAt,
-  getHtmlWithAt,
-  getHtmlWithoutAt,
-} from '../utils/mentionUtils';
+import { getRegExpWithAt, getRegExpWithoutAt } from '../utils/mentionUtils';
 
 const { ipcRenderer } = window.require('electron');
 

--- a/src/components/chat/Message.tsx
+++ b/src/components/chat/Message.tsx
@@ -51,7 +51,7 @@ const Message: FC<IProps> = ({
   const [isImagesLoaded, setIsImagesLoaded] = useState(
     numberOfImages.current === 0
   );
-  const { body } = message;
+  const { body, mentions } = message;
 
   const onMediaLoad = () => {
     numberOfLoadedImages.current++;
@@ -69,8 +69,8 @@ const Message: FC<IProps> = ({
       : '';
 
     // replace users
-    if (message.mentions.length > 0) {
-      message.mentions.forEach((mention: string) => {
+    if (mentions && mentions.length > 0) {
+      mentions.forEach((mention: string) => {
         formattedMessageBody = formattedMessageBody.replace(
           getRegExpWithAt(mention),
           getHtmlWithAt(isMe, mention)
@@ -109,7 +109,7 @@ const Message: FC<IProps> = ({
     setMessageBody(formattedMessageBody);
     setIsMe(body && body.startsWith('/me ') ? true : false);
     setIsBodyLoaded(true);
-  }, [body]);
+  }, [body, mentions, isMe]);
 
   useLayoutEffect(() => {
     if (isBodyLoaded && isImagesLoaded && onMessageLoad) {

--- a/src/components/chat/Message.tsx
+++ b/src/components/chat/Message.tsx
@@ -11,6 +11,12 @@ import { makeStyles } from '@material-ui/styles';
 import IMessage from '../../interfaces/IMessage';
 import IMessageUrl from '../../interfaces/IMessageUrl';
 import { EMOJIS, ASCII_EMOJI_MAP } from '../../utils/emojis';
+import {
+  getRegExpWithAt,
+  getHtmlWithAt,
+  getRegExpWithoutAt,
+  getHtmlWithoutAt,
+} from '../../utils/mentionUtils';
 import { ALLOWED_TAGS, ALLOWED_ATTRIBUTES } from '../../utils/sanitizeConfig';
 
 interface IProps {
@@ -61,6 +67,20 @@ const Message: FC<IProps> = ({
           allowedAttributes: ALLOWED_ATTRIBUTES,
         })
       : '';
+
+    // replace users
+    if (message.mentions.length > 0) {
+      message.mentions.forEach((mention: string) => {
+        formattedMessageBody = formattedMessageBody.replace(
+          getRegExpWithAt(mention),
+          getHtmlWithAt(isMe, mention)
+        );
+        formattedMessageBody = formattedMessageBody.replace(
+          getRegExpWithoutAt(mention),
+          getHtmlWithoutAt(isMe, mention)
+        );
+      });
+    }
 
     // replace any string emojis
     const matches = formattedMessageBody.match(/:([^:]*):/g);

--- a/src/interfaces/IMessage.ts
+++ b/src/interfaces/IMessage.ts
@@ -9,6 +9,7 @@ export default interface IMessage {
   from: string;
   body: string;
   urls: IMessageUrl[];
+  mentions: string[];
   timestamp: Moment;
   userNickname: string;
   color: string;

--- a/src/utils/mentionUtils.ts
+++ b/src/utils/mentionUtils.ts
@@ -1,0 +1,19 @@
+export const getHtmlWithAt = (isMe: boolean, nickname: string): string => {
+  return `<span class="${isMe ? 'mention-me' : 'mention'}">@${nickname}</span>`;
+};
+
+export const getHtmlWithoutAt = (isMe: boolean, nickname: string): string => {
+  return `<span class="${isMe ? 'mention-me' : 'mention'}">${nickname}</span>`;
+};
+
+export const getRegExpWithAt = (nickname: string): RegExp => {
+  return new RegExp(`@${nickname}\\b`, 'gi');
+};
+
+export const getRegExpWithoutAt = (nickname: string): RegExp => {
+  return new RegExp(
+    // TODO: test@test matches, should not match so emails get generated properly
+    `(?<=[^a-zA-Z0-9@]|\\s|^)${nickname}(?=\\W|\\s+|$)(?=[^@]|$)`,
+    'gi'
+  );
+};


### PR DESCRIPTION
User mentions are now parsed and saved when received. The replacement of the text now only occurs when being displayed, previously, this occurred when received and would be saved in the logs. This new method helps preserve the original text being sent in the logs. All old logs are backwards compatible.