### PR TITLE
Change when initial status is set

### DIFF
--- a/src/actions/connection.ts
+++ b/src/actions/connection.ts
@@ -122,7 +122,7 @@ export const connectionActions: any = {
         jid: payload.jid,
         username: payload.username,
         group: '',
-        status: 'online',
+        status: '',
         statusText: '',
         color: stringToHexColor(payload.username),
         vCard: DEFAULT_VCARD,
@@ -130,8 +130,9 @@ export const connectionActions: any = {
 
       const settings: ISettings = mapSettingsSavedToSettings(settingsSaved);
 
-      ipcRenderer.send('xmpp-roster');
+      ipcRenderer.send('xmpp-my-status', { status: 'online', statusText: '' });
       ipcRenderer.send('xmpp-get-vcard', { from: payload.jid });
+      ipcRenderer.send('xmpp-roster');
 
       // handle reconnected message if already authenticated
       let notifications = { ...state.notifications };

--- a/src/actions/user.ts
+++ b/src/actions/user.ts
@@ -99,8 +99,6 @@ export const userActions: any = {
           to: user.jid,
         });
       });
-      // update user status to online after roster is received
-      ipcRenderer.send('xmpp-my-status', 'online');
       return {
         ...state,
         profile: { ...state.profile, status: 'online' },


### PR DESCRIPTION
- The initial presence sent when connected instead of after the roster
- Params for the initial presence has been fixed