### PR TITLE
Message text display fixes

### DIFF
--- a/src/components/chat/Message.tsx
+++ b/src/components/chat/Message.tsx
@@ -83,8 +83,33 @@ const Message: FC<IProps> = ({
 
   useLayoutEffect(() => {
     let formattedMessageBody = body;
+    let newIsMe = body && body.startsWith('/me ') ? true : false;
 
     if (formattedMessageBody) {
+      // replace any string emojis
+      const matches = formattedMessageBody.match(/:([^:]*):/g);
+      if (matches) {
+        matches.forEach(element => {
+          const emoji = EMOJIS[element.substring(1, element.length - 1)];
+          if (emoji) {
+            formattedMessageBody = formattedMessageBody.replace(element, emoji);
+          }
+        });
+      }
+
+      // replace characters with emojis
+      ASCII_EMOJI_MAP.forEach(item => {
+        formattedMessageBody = formattedMessageBody.replace(
+          new RegExp(
+            '(?<=^|\\s)' +
+              item.key.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') +
+              '(?=$|\\s)',
+            'g'
+          ),
+          item.emoji
+        );
+      });
+
       formattedMessageBody = makeMarked(formattedMessageBody);
 
       // replace users
@@ -112,33 +137,14 @@ const Message: FC<IProps> = ({
         });
       }
 
-      // replace any string emojis
-      const matches = formattedMessageBody.match(/:([^:]*):/g);
-      if (matches) {
-        matches.forEach(element => {
-          const emoji = EMOJIS[element.substring(1, element.length - 1)];
-          if (emoji) {
-            formattedMessageBody = formattedMessageBody.replace(element, emoji);
-          }
-        });
+      // if isMe
+      if (isMe) {
+        formattedMessageBody = formattedMessageBody.replace('me', '');
       }
-
-      // replace characters with emojis
-      ASCII_EMOJI_MAP.forEach(item => {
-        formattedMessageBody = formattedMessageBody.replace(
-          new RegExp(
-            '(?<=^|\\s)' +
-              item.key.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') +
-              '(?=$|\\s)',
-            'g'
-          ),
-          item.emoji
-        );
-      });
     }
 
     setMessageBody(formattedMessageBody);
-    setIsMe(body && body.startsWith('/me ') ? true : false);
+    setIsMe(newIsMe);
     setIsBodyLoaded(true);
   }, [
     body,

--- a/src/components/chat/Message.tsx
+++ b/src/components/chat/Message.tsx
@@ -211,7 +211,7 @@ const Message: FC<IProps> = ({
                 .join(' ')
                 .trim()}
               dangerouslySetInnerHTML={{
-                __html: isMe ? `*${messageBody.substring(4)}*` : messageBody,
+                __html: isMe ? `*${messageBody}*` : messageBody,
               }}
             />
           </span>

--- a/src/components/chat/Message.tsx
+++ b/src/components/chat/Message.tsx
@@ -86,6 +86,11 @@ const Message: FC<IProps> = ({
     let newIsMe = body && body.startsWith('/me ') ? true : false;
 
     if (formattedMessageBody) {
+      // if isMe
+      if (isMe) {
+        formattedMessageBody = formattedMessageBody.replace('/me', '');
+      }
+
       // replace any string emojis
       const matches = formattedMessageBody.match(/:([^:]*):/g);
       if (matches) {
@@ -135,11 +140,6 @@ const Message: FC<IProps> = ({
             getHtmlWithoutAt(isMentioningMe, mention)
           );
         });
-      }
-
-      // if isMe
-      if (isMe) {
-        formattedMessageBody = formattedMessageBody.replace('me', '');
       }
     }
 


### PR DESCRIPTION
- The `me` no longer shows for `/me` messages.
- Fixed ASCII emojis not being replaced when at the start or end of a message.